### PR TITLE
Set Deadline to the New Year for 10th task

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Check Deadline
         run: |
-          deadline=2022-12-23T23:59
+          deadline=2022-12-31T23:59
           if [[ $(date +'%Y-%m-%d') > $deadline ]];
           then
               echo "FIASCO: The deadline has expired"


### PR DESCRIPTION
Shift the deadline to make it equal to the deadline for the 9th task, which must be done before the 10th